### PR TITLE
Fix mistyped env variables in `cfg` struct

### DIFF
--- a/cmd/listd/listd.go
+++ b/cmd/listd/listd.go
@@ -36,8 +36,8 @@ func main() {
 		DBUser string `envconfig:"DB_USER" default:"root"`
 		DBPass string `envconfig:"DB_PASS" default:"root"`
 		DBName string `envconfig:"DB_NAME" default:"list"`
-		DBHost string `envconfig:"DB_USER" default:"db"`
-		DBPort int    `envconfig:"DB_USER" default:"5432"`
+		DBHost string `envconfig:"DB_HOST" default:"db"`
+		DBPort int    `envconfig:"DB_PORT" default:"5432"`
 
 		ReadTimeout     time.Duration `envconfig:"READ_TIMEOUT" default:"5s"`
 		WriteTimeout    time.Duration `envconfig:"WRITE_TIMEOUT" default:"10s"`


### PR DESCRIPTION
I believe those are typos that came from a copy-paste error

I came across this project from this article https://www.ardanlabs.com/blog/2019/03/integration-testing-in-go-executing-tests-with-docker.html and noticed the mistype while I was looking through the code.

(This is not a Hacktoberfest spam PR or something like this, I just noticed something that looked wrong and wanted to help. Feel free to close this if not valid)